### PR TITLE
Add `borsh-v1` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ version = "0.4.0"
 
 [features]
 anchor = ["dep:anchor-lang"]
+borsh-v1 = []
 serde = ["dep:serde"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,7 @@
+#[cfg(all(feature = "anchor", feature = "borsh-v1"))]
+compile_error!(
+    "Features `anchor` and `borsh-v1` are mutually exclusive. \
+     Anchor uses borsh v0.10 internally and is incompatible with borsh v1."
+);
+
 pub mod types;

--- a/src/types/prefix_string.rs
+++ b/src/types/prefix_string.rs
@@ -1,5 +1,8 @@
+#[cfg(not(feature = "borsh-v1"))]
 use borsh::{BorshDeserialize, BorshSerialize};
 use borsh_1_5::io::{Error, ErrorKind, Read, Result};
+#[cfg(feature = "borsh-v1")]
+use borsh_1_5::{BorshDeserialize, BorshSerialize};
 use std::fmt::Debug;
 use std::io::Write;
 use std::ops::Deref;

--- a/src/types/prefix_vec.rs
+++ b/src/types/prefix_vec.rs
@@ -2,8 +2,11 @@ use std::fmt::Debug;
 use std::io::Write;
 use std::ops::{Deref, DerefMut};
 
-use borsh_1_5::io::Read;
+#[cfg(not(feature = "borsh-v1"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_5::io::Read;
+#[cfg(feature = "borsh-v1")]
+use borsh_1_5::{BorshDeserialize, BorshSerialize};
 
 /// Macro to automate the generation of `PrefixVec` types.
 macro_rules! prefix_vec_types {

--- a/src/types/remainder_str.rs
+++ b/src/types/remainder_str.rs
@@ -1,5 +1,8 @@
-use borsh_1_5::io::Read;
+#[cfg(not(feature = "borsh-v1"))]
 use borsh::{BorshDeserialize, BorshSerialize};
+use borsh_1_5::io::Read;
+#[cfg(feature = "borsh-v1")]
+use borsh_1_5::{BorshDeserialize, BorshSerialize};
 use std::fmt::Debug;
 use std::io::Write;
 use std::ops::Deref;

--- a/src/types/remainder_vec.rs
+++ b/src/types/remainder_vec.rs
@@ -7,10 +7,12 @@ use std::ops::{Deref, DerefMut};
 use anchor_lang::prelude::{
     AnchorDeserialize as CrateDeserialize, AnchorSerialize as CrateSerialize,
 };
+#[cfg(all(not(feature = "anchor"), not(feature = "borsh-v1")))]
+use borsh::{BorshDeserialize as CrateDeserialize, BorshSerialize as CrateSerialize};
 #[cfg(not(feature = "anchor"))]
 use borsh_1_5::io::Read;
-#[cfg(not(feature = "anchor"))]
-use borsh::{BorshDeserialize as CrateDeserialize, BorshSerialize as CrateSerialize};
+#[cfg(all(not(feature = "anchor"), feature = "borsh-v1"))]
+use borsh_1_5::{BorshDeserialize as CrateDeserialize, BorshSerialize as CrateSerialize};
 
 /// A vector that deserializes from a stream of bytes.
 ///


### PR DESCRIPTION
- Adds a borsh-v1 feature flag that switches borsh trait implementations from v0.10 to v1
- Default remains v0.10 for backward compatibility with anchor-lang 0.32

## Motivation

Unblocks: https://github.com/codama-idl/renderers-rust/pull/90

The Codama Rust renderer generates code that depends on kaigan types. An upcoming update will use solana-address, which requires borsh v1.